### PR TITLE
Fix: Extension should show offline in status bar without notification

### DIFF
--- a/src/commands/reconnect.ts
+++ b/src/commands/reconnect.ts
@@ -47,5 +47,8 @@ export const Reconnect = async (
     userAuthoredCodeReviews: codeReviews.data.authored,
   })
   StatusBar.update({ context, statusBar, state: StatusBarState.SignedIn })
+
+  commands.executeCommand(Command.activePullRequests)
+
   return
 }

--- a/src/utils/pullRequestsState.ts
+++ b/src/utils/pullRequestsState.ts
@@ -52,9 +52,6 @@ export const PullRequestState = {
       if (errorCount.count >= MAX_ERROR_COUNT) {
         StatusBar.update({ context, statusBar, state: StatusBarState.Error })
       }
-      window.showErrorMessage(
-        `Pullflow: Couldn't fetch pull requests. ${codeReviews.error.message}`
-      )
       return
     }
     await Store.set(context, {

--- a/src/views/statusBar/statusBar.ts
+++ b/src/views/statusBar/statusBar.ts
@@ -108,7 +108,7 @@ function getStatusBarText({
   const errorIcon = showErrorIcon ? '  $(warning)  ' : ''
 
   if (!pendingUserCodeReviews && !userAuthoredCodeReviews)
-    return `${presenceIcon} ${errorIcon} $(pullflow-icon)`
+    return `${errorIcon} ${presenceIcon} $(pullflow-icon)`
 
   const pendingCodeReviewsCount = pendingUserCodeReviews?.length || 0
   const authoredCodeReviewsCount = userAuthoredCodeReviews?.length || 0
@@ -124,10 +124,10 @@ function getStatusBarText({
       userAuthoredCodeReviews?.map(
         (codeReview) => `$(${PullRequestIcons.getIcon(codeReview.botReaction)})`
       ) || []
-    return `${presenceIcon} ${pendingCodeReviewIcons.join(
+    return `${errorIcon} ${presenceIcon} ${pendingCodeReviewIcons.join(
       ''
-    )} ${errorIcon} $(pullflow-icon) ${authoredCodeReviewIcons.join('')}`
+    )} $(pullflow-icon) ${authoredCodeReviewIcons.join('')}`
   } else {
-    return `${presenceIcon} ${pendingCodeReviewsCount} ${errorIcon} $(pullflow-icon) ${authoredCodeReviewsCount}`
+    return `${errorIcon} ${presenceIcon} ${pendingCodeReviewsCount} $(pullflow-icon) ${authoredCodeReviewsCount}`
   }
 }

--- a/src/views/statusBar/statusBar.ts
+++ b/src/views/statusBar/statusBar.ts
@@ -68,11 +68,15 @@ export const StatusBar = {
     log.info('updating status bar', module)
 
     if (state === StatusBarState.SignedIn) {
-      statusBarProperties.signedIn.text = getStatusBarText(context)
+      statusBarProperties.signedIn.text = getStatusBarText({ context })
       statusBar = Object.assign(statusBar, statusBarProperties.signedIn)
     } else if (state === StatusBarState.Loading) {
       statusBar = Object.assign(statusBar, statusBarProperties.loading)
     } else if (state === StatusBarState.Error) {
+      statusBarProperties.error.text = getStatusBarText({
+        context,
+        showErrorIcon: true,
+      })
       statusBar = Object.assign(statusBar, statusBarProperties.error)
     } else {
       statusBar = Object.assign(statusBar, statusBarProperties.signedOut)
@@ -82,7 +86,13 @@ export const StatusBar = {
 }
 
 /** computes status bar text */
-function getStatusBarText(context: ExtensionContext): string {
+function getStatusBarText({
+  context,
+  showErrorIcon = false,
+}: {
+  context: ExtensionContext
+  showErrorIcon?: boolean
+}): string {
   if (STATUS_BAR_ICON_PREVIEW) {
     const allIcons = IconReference.map((k) => `$(${k})`).join('')
     return '$(pullflow-icon)' + allIcons
@@ -93,12 +103,15 @@ function getStatusBarText(context: ExtensionContext): string {
     previousPresenceStatus,
   } = Store.get(context)
 
-  if (!pendingUserCodeReviews && !userAuthoredCodeReviews) return ''
+  const presenceIcon =
+    previousPresenceStatus === PresenceStatus.Flow ? '$(symbol-event)' : ''
+  const errorIcon = showErrorIcon ? '  $(warning)  ' : ''
+
+  if (!pendingUserCodeReviews && !userAuthoredCodeReviews)
+    return `${presenceIcon} ${errorIcon} $(pullflow-icon)`
 
   const pendingCodeReviewsCount = pendingUserCodeReviews?.length || 0
   const authoredCodeReviewsCount = userAuthoredCodeReviews?.length || 0
-  const presenceIcon =
-    previousPresenceStatus === PresenceStatus.Flow ? '$(symbol-event)' : ''
   if (
     pendingCodeReviewsCount < MAX_PR_COUNT &&
     authoredCodeReviewsCount < MAX_PR_COUNT
@@ -113,8 +126,8 @@ function getStatusBarText(context: ExtensionContext): string {
       ) || []
     return `${presenceIcon} ${pendingCodeReviewIcons.join(
       ''
-    )} $(pullflow-icon)\t${authoredCodeReviewIcons.join('')}`
+    )} ${errorIcon} $(pullflow-icon) ${authoredCodeReviewIcons.join('')}`
   } else {
-    return `${presenceIcon} ${pendingCodeReviewsCount} $(pullflow-icon) ${authoredCodeReviewsCount}`
+    return `${presenceIcon} ${pendingCodeReviewsCount} ${errorIcon} $(pullflow-icon) ${authoredCodeReviewsCount}`
   }
 }


### PR DESCRIPTION
### Summary of Changes 

- added `warning icon ⚠️` for offline status
- removed notifications for offline status error
- updated reconnect command to run `activePullRequest` command when user clicks status bar


### Snap-Shots

<img width="96" alt="Screenshot 2023-11-01 at 12 29 08 AM" src="https://github.com/pullflow/vscode-pullflow/assets/110373493/55645028-7dc7-4831-ae28-f6cdc1f6280b">

<img width="96" alt="Screenshot 2023-11-01 at 12 30 42 AM" src="https://github.com/pullflow/vscode-pullflow/assets/110373493/5bda2d0c-2e3d-4b88-9dd0-861007358ee4">



### PR-Specific Tests

- User signs in on extension > User see pull requests on status bar > User turns off internet > User sees warning icon next to Pullflow icon > User turns on internet > User clicks status bar > User sees updated pull requests on quick pick. 