### PR TITLE
Refactor: Rename login and logout command to sign in and sign out

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The **Pullflow VS Code extension** brings all your code review workflows and col
 ---
 
 1. **Installation**: Install the “Pullflow” extension from the Visual Studio Marketplace or Open VSX Registry.
-2. **Login**: Click on “Sign in to Pullflow” from the VS Code status bar.
+2. **Sign in**: Click on “Sign in to Pullflow” from the VS Code status bar.
 3. **Ready to use**: The extension is now ready to use ✨
 
 ## Key Features

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
         "title": "Pullflow: Active Pull Requests"
       },
       {
-        "command": "pullflow.login",
-        "title": "Pullflow: Login"
+        "command": "pullflow.signIn",
+        "title": "Pullflow: Sign in"
       },
       {
         "command": "pullflow.logout",

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
         "title": "Pullflow: Sign in"
       },
       {
-        "command": "pullflow.logout",
-        "title": "Pullflow: Logout"
+        "command": "pullflow.signOut",
+        "title": "Pullflow: Sign out"
       },
       {
         "command": "pullflow.reconnect",

--- a/src/commands/reconnect.ts
+++ b/src/commands/reconnect.ts
@@ -29,7 +29,7 @@ export const Reconnect = async (
   if (codeReviews.requireRelogin) {
     log.error(codeReviews.error, module)
     window.showInformationMessage(`Pullflow: Please login again`)
-    commands.executeCommand(Command.logout)
+    commands.executeCommand(Command.signOut)
     return
   }
 

--- a/src/commands/signIn.ts
+++ b/src/commands/signIn.ts
@@ -5,7 +5,7 @@ import { initialize } from '../utils/initialize'
 
 const SIGN_IN_TIME_OUT = 120000 // sign in time out in ms
 
-export const Login = async ({
+export const SignIn = async ({
   context,
   statusBar,
 }: {
@@ -13,11 +13,11 @@ export const Login = async ({
   statusBar: StatusBarItem
 }) => {
   const redirectUri = `${env.uriScheme}://${context.extension.packageJSON.publisher}.${context.extension.packageJSON.name}`
-  const loginUrl = AppConfig.pullflow.baseUrl
+  const signInUrl = AppConfig.pullflow.baseUrl
 
   env.openExternal(
     Uri.parse(
-      `${loginUrl}/?clientIdentifier=${AppConfig.app.clientIdentifier}&clientUri=${redirectUri}`
+      `${signInUrl}/?clientIdentifier=${AppConfig.app.clientIdentifier}&clientUri=${redirectUri}`
     )
   )
   const user = await Authorization.waitForUser(context, SIGN_IN_TIME_OUT)

--- a/src/commands/signOut.ts
+++ b/src/commands/signOut.ts
@@ -4,7 +4,7 @@ import { StatusBar } from '../views/statusBar/statusBar'
 import { StatusBarState } from '../utils'
 import { Store } from '../utils/store'
 
-export const Logout = async ({
+export const SignOut = async ({
   context,
   statusBar,
   pollIntervalId,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@ import { Command } from './utils'
 import { initialize } from './utils/initialize'
 import { Store } from './utils/store'
 import { Reconnect } from './commands/reconnect'
-import { Logout } from './commands/logout'
+import { SignOut } from './commands/signOut'
 import { ActivePullRequests } from './commands/activePullRequests'
 import { Authorization } from './utils/authorization'
 import { ToggleFlowState } from './commands/toggleFlowState'
@@ -49,8 +49,8 @@ export async function activate(context: ExtensionContext) {
     )
   )
   context.subscriptions.push(
-    commands.registerCommand(Command.logout, () =>
-      Logout({
+    commands.registerCommand(Command.signOut, () =>
+      SignOut({
         context,
         statusBar,
         pollIntervalId,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 import { ExtensionContext, commands, StatusBarItem, window, Uri } from 'vscode'
 import { log } from './utils/logger'
-import { Login } from './commands/login'
+import { SignIn } from './commands/signIn'
 import { StatusBar } from './views/statusBar/statusBar'
 import { Command } from './utils'
 import { initialize } from './utils/initialize'
@@ -44,7 +44,9 @@ export async function activate(context: ExtensionContext) {
   })
 
   context.subscriptions.push(
-    commands.registerCommand(Command.login, () => Login({ context, statusBar }))
+    commands.registerCommand(Command.signIn, () =>
+      SignIn({ context, statusBar })
+    )
   )
   context.subscriptions.push(
     commands.registerCommand(Command.logout, () =>

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -1,7 +1,7 @@
 export const Command = {
   signIn: 'pullflow.signIn',
   activePullRequests: 'pullflow.active-pull-requests',
-  logout: 'pullflow.logout',
+  signOut: 'pullflow.signOut',
   reconnect: 'pullflow.reconnect',
   toggleFlowState: 'pullflow.toggle-flow-state',
   welcomeView: 'pullflow.welcome-view',

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -1,5 +1,5 @@
 export const Command = {
-  login: 'pullflow.login',
+  signIn: 'pullflow.signIn',
   activePullRequests: 'pullflow.active-pull-requests',
   logout: 'pullflow.logout',
   reconnect: 'pullflow.reconnect',

--- a/src/utils/initialize.ts
+++ b/src/utils/initialize.ts
@@ -107,7 +107,7 @@ const setSpaceUsers = async ({
     window.showInformationMessage(
       `Error in fetching space users ${spaceUsers.error || spaceUsers.message}`
     )
-    commands.executeCommand(Command.logout)
+    commands.executeCommand(Command.signOut)
     return
   }
 

--- a/src/utils/pullRequestsState.ts
+++ b/src/utils/pullRequestsState.ts
@@ -43,7 +43,7 @@ export const PullRequestState = {
     if (codeReviews.requireRelogin) {
       log.error(codeReviews.error, module)
       window.showInformationMessage(`Pullflow: Please login again`)
-      commands.executeCommand(Command.logout)
+      commands.executeCommand(Command.signOut)
       return
     }
 

--- a/src/views/statusBar/statusBar.ts
+++ b/src/views/statusBar/statusBar.ts
@@ -26,7 +26,7 @@ const statusBarProperties = {
     tooltip: 'Pullflow - Active Pull Requests',
   },
   signedOut: {
-    command: Command.login,
+    command: Command.signIn,
     backgroundColor: new ThemeColor(Theme.statusBar.error),
     text: '⚠ Sign in to Pullflow',
     tooltip: 'Sign in to Pullflow account',

--- a/src/views/webviews/welcome/welcome.ts
+++ b/src/views/webviews/welcome/welcome.ts
@@ -117,7 +117,7 @@ export const Welcome = {
                   <td>Pullflow: Active Pull Requests (Ctrl/Cmd+Shift+,)</td>
                 </tr>
                 <tr>
-                  <td>Pullflow: Login</td>
+                  <td>Pullflow: Sign in</td>
                 </tr>
                 <tr>
                   <td>Pullflow: Logout</td>

--- a/src/views/webviews/welcome/welcome.ts
+++ b/src/views/webviews/welcome/welcome.ts
@@ -120,7 +120,7 @@ export const Welcome = {
                   <td>Pullflow: Sign in</td>
                 </tr>
                 <tr>
-                  <td>Pullflow: Logout</td>
+                  <td>Pullflow: Sign out</td>
                 </tr>
                 <tr>
                   <td>Pullflow: Reconnect</td>


### PR DESCRIPTION
### Summary of Changes 

- renamed `login` command to `sign in` 
- updated welcome page
- updated `Read.me`


### PR-Snap-Shots

<img width="1058" alt="Screenshot 2023-11-07 at 3 04 25 AM" src="https://github.com/pullflow/vscode-pullflow/assets/110373493/ddbd04b3-ced9-4e9c-849d-1ae1e8e0f990">

### PR-Specific-Tests

- Test `Pullflow: Sign in` and `Pullflow: Sign out` commands 
