### PR TITLE
Feature: Set reminders on Pull requests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,7 +3,7 @@
 // Hover to view descriptions of existing attributes.
 // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 {
-	"version": "1.0.1",
+	"version": "1.1.0",
 	"configurations": [
 		{
 			"name": "Run Extension",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "Pullflow",
   "displayName": "Pullflow",
   "description": "Code review collaboration across GitHub, Slack, and VS Code.",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "preview": true,
   "license": "MIT",
   "engines": {

--- a/src/api/pullRequestQuickActionsApi.ts
+++ b/src/api/pullRequestQuickActionsApi.ts
@@ -41,6 +41,15 @@ const REQUEST_REVIEW = `
   }
 `
 
+const SET_REMINDER = `
+mutation setCodeReviewReminder($codeReviewId: String!, $duration: Int!) {
+  setCodeReviewReminder(codeReviewId: $codeReviewId, duration: $duration) {
+    success
+    message
+  }
+}
+`
+
 export const PullRequestQuickActionsApi = {
   addLabels: async ({
     authToken,
@@ -144,6 +153,32 @@ export const PullRequestQuickActionsApi = {
         eventProvider,
       })
       return data.requestReview
+    } catch (error) {
+      log.error(`error in requesting review, ${error}`, module)
+      return { error }
+    }
+  },
+
+  setReminder: async ({
+    duration,
+    codeReviewId,
+    authToken,
+    context,
+  }: {
+    duration: number
+    codeReviewId: string
+    authToken: string
+    context: ExtensionContext
+  }) => {
+    log.info(`setting reminder: ${{ duration, codeReviewId }}}`, module)
+
+    const pullflowApi = new PullflowApi(context, authToken)
+    try {
+      const data = await pullflowApi.fetch(SET_REMINDER, {
+        codeReviewId,
+        duration,
+      })
+      return data.setCodeReviewReminder
     } catch (error) {
       log.error(`error in requesting review, ${error}`, module)
       return { error }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -75,6 +75,10 @@ export interface ReviewerSelectionItem extends QuickPickItem {
   hasUser: boolean
   xid: string
 }
+export interface SpaceUserSelectionItem extends QuickPickItem {
+  label: string
+  description: string
+}
 export enum CodeReviewType {
   Pending,
   Authored,
@@ -89,6 +93,7 @@ export enum ActivePullRequestActions {
   ApplyLabel = 'Add label',
   AddAssignee = 'Add assignee',
   RequestReview = 'Add reviewer',
+  SetReminder = 'Set a reminder',
 }
 export type SpaceUser = {
   id: string
@@ -112,6 +117,7 @@ export type ApiVariables =
   | AddAssigneeVariables
   | RequestReviewVariables
   | CodeReviewApproveVariables
+  | CodeReviewRemindersVariables
 export type ThreadMessageVariables = {
   body: string
   parentMessageXid: string
@@ -148,6 +154,10 @@ export type RequestReviewVariables = {
 export type CodeReviewApproveVariables = {
   codeReviewId: string
   body?: string
+}
+export type CodeReviewRemindersVariables = {
+  codeReviewId: string
+  duration: number
 }
 export type RepoInfo = {
   repoName?: string

--- a/src/views/quickpicks/pullRequestActionPicker.ts
+++ b/src/views/quickpicks/pullRequestActionPicker.ts
@@ -32,6 +32,7 @@ const getActionItems = (type: CodeReviewType) => [
   {
     label: ActivePullRequestActions.RequestReview,
   },
+  { label: ActivePullRequestActions.SetReminder },
 ]
 
 export const pullRequestActionPicker = ({

--- a/src/views/quickpicks/quickPick.ts
+++ b/src/views/quickpicks/quickPick.ts
@@ -1,18 +1,18 @@
 import { QuickPickItem, window } from 'vscode'
 
 export const QuickPick = {
-  create: ({
+  create: <Type extends QuickPickItem>({
     items,
     title,
     placeholder,
     onDidChangeSelection,
   }: {
-    items: QuickPickItem[]
+    items: Type[]
     title: string
     placeholder: string
-    onDidChangeSelection: (selection: readonly QuickPickItem[]) => void
+    onDidChangeSelection: (selection: readonly Type[]) => void
   }) => {
-    const quickPick = window.createQuickPick()
+    const quickPick = window.createQuickPick<Type>()
     quickPick.items = items
     quickPick.title = title
     quickPick.placeholder = placeholder

--- a/src/views/quickpicks/selectHandlers/pullRequestActionHandler.ts
+++ b/src/views/quickpicks/selectHandlers/pullRequestActionHandler.ts
@@ -87,6 +87,12 @@ export const pullRequestActionHandler = async ({
       statusBar,
     })
   }
+  if (selectedItem?.label === ActivePullRequestActions.SetReminder) {
+    await PullRequestQuickActions.setReminder({
+      codeReview: codeReviewItem,
+      context,
+    })
+  }
 }
 
 const openLink = (link: string) => env.openExternal(Uri.parse(link))

--- a/src/views/quickpicks/spaceUserPicker.ts
+++ b/src/views/quickpicks/spaceUserPicker.ts
@@ -1,6 +1,6 @@
 import { ExtensionContext, window } from 'vscode'
 import { Store } from '../../utils/store'
-import { SpaceUser } from '../../utils'
+import { SpaceUser, SpaceUserSelectionItem } from '../../utils'
 import { QuickPick } from './quickPick'
 
 export const spaceUserPicker = ({
@@ -12,7 +12,9 @@ export const spaceUserPicker = ({
   context: ExtensionContext
   placeholder: string
   title: string
-  onDidChangeSelection: (item: any) => Promise<boolean>
+  onDidChangeSelection: (
+    item: readonly SpaceUserSelectionItem[]
+  ) => Promise<boolean>
 }) => {
   const spaceUsers = Store.get(context)?.spaceUsers
   if (!spaceUsers) {

--- a/src/views/quickpicks/timePicker.ts
+++ b/src/views/quickpicks/timePicker.ts
@@ -1,0 +1,41 @@
+import { QuickPickItem } from 'vscode'
+import { QuickPick } from './quickPick'
+
+export interface TimeSelectionItem extends QuickPickItem {
+  value: number
+}
+export const TimeIntervals: TimeSelectionItem[] = [
+  {
+    label: '30 minutes',
+    value: 30,
+  },
+  {
+    label: '45 minutes',
+    value: 45,
+  },
+  {
+    label: '1 hour',
+    value: 60,
+  },
+  {
+    label: '2 hours',
+    value: 120,
+  },
+]
+
+export const timePicker = ({
+  title,
+  onDidChangeSelection,
+}: {
+  title: string
+  onDidChangeSelection: (
+    selection: readonly TimeSelectionItem[]
+  ) => Promise<Boolean>
+}) => {
+  QuickPick.create({
+    items: TimeIntervals,
+    title,
+    placeholder: 'Choose time interval',
+    onDidChangeSelection,
+  })
+}


### PR DESCRIPTION
Summary: 
- Bumped version to 1.1.0
- Added reminders task in pr action picker and handler
- added method and api for reminder time selection
- fixed typing on quickpick

Note: Requires deployment of Pullflow core with 1.1.0 support