### PR TITLE
Feature: Add refresh action on pull request actions

### DIFF
--- a/src/api/pullRequestQuickActionsApi.ts
+++ b/src/api/pullRequestQuickActionsApi.ts
@@ -168,7 +168,7 @@ export const PullRequestQuickActionsApi = {
     }
   },
 
-  refreshCodeReview: async ({
+  refresh: async ({
     codeReviewId,
     authToken,
     context,

--- a/src/api/pullRequestQuickActionsApi.ts
+++ b/src/api/pullRequestQuickActionsApi.ts
@@ -41,6 +41,15 @@ const REQUEST_REVIEW = `
   }
 `
 
+const REFRESH_CODE_REVIEW = `
+mutation refreshCodeReview($codeReviewId: String!) {
+  refreshCodeReview(codeReviewId: $codeReviewId) {
+    success
+    message
+  }
+}
+`
+
 const SET_REMINDER = `
 mutation setCodeReviewReminder($codeReviewId: String!, $duration: Int!) {
   setCodeReviewReminder(codeReviewId: $codeReviewId, duration: $duration) {
@@ -153,6 +162,29 @@ export const PullRequestQuickActionsApi = {
         eventProvider,
       })
       return data.requestReview
+    } catch (error) {
+      log.error(`error in requesting review, ${error}`, module)
+      return { error }
+    }
+  },
+
+  refreshCodeReview: async ({
+    codeReviewId,
+    authToken,
+    context,
+  }: {
+    codeReviewId: string
+    authToken: string
+    context: ExtensionContext
+  }) => {
+    log.info(`requesting review: ${{ codeReviewId }}}`, module)
+
+    const pullflowApi = new PullflowApi(context, authToken)
+    try {
+      const data = await pullflowApi.fetch(REFRESH_CODE_REVIEW, {
+        codeReviewId,
+      })
+      return data.refreshCodeReview
     } catch (error) {
       log.error(`error in requesting review, ${error}`, module)
       return { error }

--- a/src/pullRequestQuickActions/pullRequestQuickActions.ts
+++ b/src/pullRequestQuickActions/pullRequestQuickActions.ts
@@ -11,9 +11,9 @@ import { spaceUserPicker } from '../views/quickpicks/spaceUserPicker'
 import { Presence } from '../models/presence'
 import { Store } from '../utils/store'
 import { StatusBar } from '../views/statusBar/statusBar'
-import { initialize } from '../utils/initialize'
 import { TimeSelectionItem, timePicker } from '../views/quickpicks/timePicker'
 import moment = require('moment')
+import { PullRequestState } from '../utils/pullRequestsState'
 
 export const PullRequestQuickActions = {
   applyLabel: async ({
@@ -239,7 +239,12 @@ export const PullRequestQuickActions = {
       return false
     }
 
-    await initialize({ context, statusBar }) // refetch pull requests
+    await PullRequestState.update({
+      context,
+      statusBar,
+      isLogin: true,
+      errorCount: { count: 0 },
+    }) // refetch pull requests
 
     await Presence.set({
       status: PresenceStatus.Active,

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -93,6 +93,7 @@ export enum ActivePullRequestActions {
   ApplyLabel = 'Add label',
   AddAssignee = 'Add assignee',
   RequestReview = 'Add reviewer',
+  Refresh = 'Refresh',
   SetReminder = 'Set a reminder',
 }
 export type SpaceUser = {
@@ -118,6 +119,7 @@ export type ApiVariables =
   | RequestReviewVariables
   | CodeReviewApproveVariables
   | CodeReviewRemindersVariables
+  | RefreshCodeReviewVariables
 export type ThreadMessageVariables = {
   body: string
   parentMessageXid: string
@@ -162,4 +164,7 @@ export type CodeReviewRemindersVariables = {
 export type RepoInfo = {
   repoName?: string
   branch?: string
+}
+export type RefreshCodeReviewVariables = {
+  codeReviewId: string
 }

--- a/src/views/quickpicks/pullRequestActionPicker.ts
+++ b/src/views/quickpicks/pullRequestActionPicker.ts
@@ -33,6 +33,9 @@ const getActionItems = (type: CodeReviewType) => [
     label: ActivePullRequestActions.RequestReview,
   },
   { label: ActivePullRequestActions.SetReminder },
+  {
+    label: ActivePullRequestActions.Refresh,
+  },
 ]
 
 export const pullRequestActionPicker = ({

--- a/src/views/quickpicks/selectHandlers/pullRequestActionHandler.ts
+++ b/src/views/quickpicks/selectHandlers/pullRequestActionHandler.ts
@@ -93,6 +93,13 @@ export const pullRequestActionHandler = async ({
       context,
     })
   }
+  if (selectedItem?.label === ActivePullRequestActions.Refresh) {
+    await PullRequestQuickActions.refresh({
+      codeReviewId: codeReviewItem.id,
+      context,
+      statusBar,
+    })
+  }
 }
 
 const openLink = (link: string) => env.openExternal(Uri.parse(link))


### PR DESCRIPTION
### Summary of Changes

- added `Refresh` pull request action.
- added mutation for `refreshCodeReview` in `pullRequestQuickActionsApi.ts`.
- created refresh function in `pullRequestQuickActions.ts`.


### PR-Specific-Tests

- User creates PR > PR is shown in quick pick > Shut down `Pullflow` server > User closes PR > PR is still shown in vscode > User refreshed PR > PR is not shown in vscode anymore. 