### PR TITLE
Fix: Add missing header types in Pullflow Api 

### DIFF
--- a/src/utils/pullflowApi.ts
+++ b/src/utils/pullflowApi.ts
@@ -5,13 +5,7 @@ import { AppConfig } from './appConfig'
 
 export class PullflowApi {
   apiUrl: string
-  options: {
-    method: string
-    headers: {
-      authorization: string
-      version: string
-    }
-  }
+  options: {}
 
   constructor(
     context: ExtensionContext,
@@ -23,6 +17,8 @@ export class PullflowApi {
       headers: {
         authorization: accessToken ?? '',
         version: context.extension.packageJSON.version,
+        Accept: 'application/json, text/plain',
+        'Content-Type': 'application/json;charset=UTF-8',
       },
     }
     this.apiUrl = AppConfig.pullflow.graphqlUrl


### PR DESCRIPTION
Summary: 
Pullflow 1.15 requires `Content-Type` to be explicitly sent in the headers. Updated the PullflowApi class to send `Accept` and `Content-Type` in headers. 