### PR TITLE
Fix: Display error message on failed to pull pull requests from Core

### DIFF
--- a/src/utils/pullRequestsState.ts
+++ b/src/utils/pullRequestsState.ts
@@ -52,6 +52,9 @@ export const PullRequestState = {
       if (errorCount.count >= MAX_ERROR_COUNT) {
         StatusBar.update({ context, statusBar, state: StatusBarState.Error })
       }
+      window.showErrorMessage(
+        `Pullflow: Couldn't fetch pull requests. ${codeReviews.error.message}`
+      )
       return
     }
     await Store.set(context, {


### PR DESCRIPTION
### Summary

This pull request adds an error message to the user interface when the pull request fetch fails. The error message is displayed using the `window.showErrorMessage` method and includes the specific error message returned by the API. This provides better feedback to the user when there is an issue with fetching pull requests.

This is especially useful for incompatible extension version errors.