### PR TITLE
Fix: Replace GitHub tag with user's name in Extensions notifications

### DIFF
--- a/src/pullRequestQuickActions/pullRequestQuickActions.ts
+++ b/src/pullRequestQuickActions/pullRequestQuickActions.ts
@@ -201,7 +201,7 @@ export const PullRequestQuickActions = {
         }
 
         window.showInformationMessage(
-          `Pullflow: ${item[0].description} added as reviewer to pull request`
+          `Pullflow: ${item[0].label} added as reviewer to pull request`
         )
         return true
       },


### PR DESCRIPTION
#### Summary of Changes

- fix: showing full name for reviewer in pop up


### Snap-Shots 

<img width="510" alt="Screenshot 2023-12-11 at 6 06 54 PM" src="https://github.com/pullflow/vscode-pullflow/assets/110373493/eeeb73fe-756a-4b06-a0f0-2bcc5f89eb3e">
