### PR TITLE
Fix: Shows empty quickpick when no pending PR tasks

### DIFF
--- a/src/commands/activePullRequests.ts
+++ b/src/commands/activePullRequests.ts
@@ -1,4 +1,4 @@
-import { ExtensionContext, StatusBarItem } from 'vscode'
+import { ExtensionContext, StatusBarItem, window } from 'vscode'
 import { Store } from '../utils/store'
 import { ActivePullRequestItems } from '../views/quickpicks/items/activePullRequestItems'
 import { pullRequestActionPicker } from '../views/quickpicks/pullRequestActionPicker'
@@ -11,6 +11,14 @@ export const ActivePullRequests = (
 ) => {
   const codeReviews = Store.get(context)
   if (!codeReviews) return
+
+  if (
+    !codeReviews?.pendingUserCodeReviews?.length &&
+    !codeReviews?.userAuthoredCodeReviews?.length
+  ) {
+    window.showInformationMessage('Pullflow: You have no PRs waiting for you.')
+    return
+  }
 
   const activePullRequestItems = ActivePullRequestItems.get(codeReviews)
 


### PR DESCRIPTION
### Summary of Changes 

- fix: showing pop up for empty quick pick


### Snap-Shots

<img width="489" alt="Screenshot 2023-12-21 at 12 23 54 PM" src="https://github.com/pullflow/vscode-pullflow/assets/110373493/4e65e48d-7fbe-4cd9-aeab-511a36b3ec6f">


### PR-Specific-Tests

- User signs in on Pullflow > User signs in on extension > User clicks `Pullflow icon` > User sees pop up saying `Pullflow: You have no PRs waiting for you.`