### PR TITLE
Fix: VSCode doesn't remove flow icon; removed from Slack

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,7 +19,7 @@ export async function activate(context: ExtensionContext) {
   log.info('activating extension', module)
 
   checkFirstActivation(context)
-  UserPresence.resetState(context)
+  await UserPresence.resetState(context)
 
   const statusBar: StatusBarItem = await StatusBar.activate(context)
   const { pollIntervalId, focusStateEvent, presenceInterval } =

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import { ActivePullRequests } from './commands/activePullRequests'
 import { Authorization } from './utils/authorization'
 import { ToggleFlowState } from './commands/toggleFlowState'
 import { Welcome } from './views/webviews/welcome/welcome'
+import { UserPresence } from './userPresence/userPresence'
 
 const module = 'extension.ts'
 
@@ -18,6 +19,7 @@ export async function activate(context: ExtensionContext) {
   log.info('activating extension', module)
 
   checkFirstActivation(context)
+  UserPresence.resetState(context)
 
   const statusBar: StatusBarItem = await StatusBar.activate(context)
   const { pollIntervalId, focusStateEvent, presenceInterval } =

--- a/src/userPresence/trackUserPresence.ts
+++ b/src/userPresence/trackUserPresence.ts
@@ -3,7 +3,7 @@ import { Store } from '../utils/store'
 import { UserPresence } from './userPresence'
 import { log } from '../utils/logger'
 
-const USER_FLOW_INTERVAL = 1000 * 60 * 2 // 2 minutes
+const USER_FLOW_INTERVAL = 5 * 60 * 1000 // 5 minutes
 const module = 'TrackUserFlow.ts'
 
 export const trackUserPresence = (

--- a/src/userPresence/trackUserPresence.ts
+++ b/src/userPresence/trackUserPresence.ts
@@ -3,7 +3,7 @@ import { Store } from '../utils/store'
 import { UserPresence } from './userPresence'
 import { log } from '../utils/logger'
 
-const USER_FLOW_INTERVAL = 5 * 60 * 1000 // 5 minutes
+const USER_FLOW_INTERVAL = 2 * 60 * 1000 // 2 minutes
 const module = 'TrackUserFlow.ts'
 
 export const trackUserPresence = (

--- a/src/userPresence/userPresence.ts
+++ b/src/userPresence/userPresence.ts
@@ -33,6 +33,7 @@ export const UserPresence = {
         })
         await Store.set(context, {
           previousPresenceStatus: PresenceStatus.Flow,
+          keyStrokeCount: 0,
         })
         return
       }
@@ -41,7 +42,7 @@ export const UserPresence = {
     const timeSinceLastKeyStroke =
       new Date().getTime() - (lastKeyStrokeTime || 0)
 
-    // if user has not typed anything in a while and was not active before
+    // if user has not typed anything in a while
     if (timeSinceLastKeyStroke > KEY_STROKE_INTERVAL) {
       await Store.set(context, { keyStrokeCount: 0 })
       if (isFocused && lastFocusedTime) {
@@ -60,5 +61,18 @@ export const UserPresence = {
         }
       }
     }
+    await Presence.set({
+      status: PresenceStatus.Inactive,
+      context,
+      statusBar,
+    })
+  },
+
+  resetState: async (context: ExtensionContext) => {
+    await Store.set(context, {
+      lastFocusedTime: 0,
+      keyStrokeCount: 0,
+      lastKeyStrokeTime: 0,
+    })
   },
 }

--- a/src/userPresence/userPresence.ts
+++ b/src/userPresence/userPresence.ts
@@ -26,14 +26,14 @@ export const UserPresence = {
     if (currentKeyStrokeCount) {
       // if the user has typed enough keys and was not in flow before
       if (currentKeyStrokeCount >= KEY_STROKE_COUNT) {
+        await Store.set(context, {
+          previousPresenceStatus: PresenceStatus.Flow,
+          keyStrokeCount: 0,
+        })
         await Presence.set({
           status: PresenceStatus.Flow,
           context,
           statusBar,
-        })
-        await Store.set(context, {
-          previousPresenceStatus: PresenceStatus.Flow,
-          keyStrokeCount: 0,
         })
         return
       }
@@ -49,18 +49,21 @@ export const UserPresence = {
         const timeSinceLastFocus = new Date().getTime() - lastFocusedTime
         // if user has been in focused mode for a while
         if (timeSinceLastFocus > FOCUS_INTERVAL) {
+          await Store.set(context, {
+            previousPresenceStatus: PresenceStatus.Active,
+          })
           await Presence.set({
             status: PresenceStatus.Active,
             context,
             statusBar,
           })
-          await Store.set(context, {
-            previousPresenceStatus: PresenceStatus.Active,
-          })
           return
         }
       }
     }
+    await Store.set(context, {
+      previousPresenceStatus: PresenceStatus.Inactive,
+    })
     await Presence.set({
       status: PresenceStatus.Inactive,
       context,


### PR DESCRIPTION
### Summary of Changes 

- reseting `UserPresence.resetState` on activation.
- added `INACTIVE` state for presence.


PR-Specific-Tests

- Slack status and VS Code status bar are always in sync for flow icon. 