### PR TITLE
Fix API for SpaceUsers to match Pullflow 2.0

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,7 +3,7 @@
 // Hover to view descriptions of existing attributes.
 // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 {
-	"version": "1.3.0",
+	"version": "2.0.0",
 	"configurations": [
 		{
 			"name": "Run Extension",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "Pullflow",
   "displayName": "Pullflow",
   "description": "Code review collaboration across GitHub, Slack, and VS Code.",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "preview": true,
   "license": "MIT",
   "engines": {

--- a/src/api/spaceUsersApi.ts
+++ b/src/api/spaceUsersApi.ts
@@ -4,8 +4,8 @@ import { PullflowApi } from '../utils/pullflowApi'
 
 const module = 'spaceUsersApi.ts'
 
-const SPACE_USERS_QUERY = `query spaceUsersForVscode {
-	spaceUsersForVscode {
+const SPACE_USERS_QUERY = `query spaceUsersForVscode($codeReviewId: String!) {
+	spaceUsersForVscode(codeReviewId: $codeReviewId) {
     message
     spaceUsers {
 		  name
@@ -16,17 +16,19 @@ const SPACE_USERS_QUERY = `query spaceUsersForVscode {
 `
 export const SpaceUsersApi = {
   get: async ({
-    context,
     authToken,
+    codeReviewId,
+    context,
   }: {
     authToken: string
+    codeReviewId: string
     context: ExtensionContext
   }) => {
     log.info(`fetching space users`, module)
 
     const pullflowApi = new PullflowApi(context, authToken)
     try {
-      const data = await pullflowApi.fetch(SPACE_USERS_QUERY)
+      const data = await pullflowApi.fetch(SPACE_USERS_QUERY, { codeReviewId })
       return data.spaceUsersForVscode
     } catch (e) {
       log.error(`error in fetching space users, ${e}`, module)

--- a/src/models/spaceUsers.ts
+++ b/src/models/spaceUsers.ts
@@ -1,0 +1,29 @@
+import { ExtensionContext, window } from 'vscode'
+import { Authorization } from '../utils/authorization'
+import { SpaceUsersApi } from '../api/spaceUsersApi'
+
+export const SpaceUsers = {
+  get: async ({
+    context,
+    codeReviewId,
+  }: {
+    context: ExtensionContext
+    codeReviewId: string
+  }) => {
+    const session = await Authorization.currentSession(context)
+    const response = await SpaceUsersApi.get({
+      codeReviewId,
+      authToken: session?.accessToken ?? '',
+      context,
+    })
+
+    if (!response || response.message || response.error) {
+      window.showInformationMessage(
+        `Failed to fetch space users, please try again.`
+      )
+      return false
+    }
+
+    return response.spaceUsers
+  },
+}

--- a/src/pullRequestQuickActions/pullRequestQuickActions.test.ts
+++ b/src/pullRequestQuickActions/pullRequestQuickActions.test.ts
@@ -39,6 +39,7 @@ describe('Pull Request Quick Actions', () => {
   })
 
   it('adds assignee to pull request', async () => {
+    mockSpaceUsers.SpaceUsers.get.mockReturnValue([])
     await subject().addAssignee({
       codeReview: mockModel,
       context: mockModel,
@@ -49,6 +50,7 @@ describe('Pull Request Quick Actions', () => {
         context: mockModel,
         placeholder: 'Select a user',
         title: 'Add assignee to pull request',
+        spaceUsers: [],
       })
     )
     expect(mockPresence.Presence.set).toBeCalled()
@@ -56,6 +58,7 @@ describe('Pull Request Quick Actions', () => {
   })
 
   it('adds reviewer on pull request', async () => {
+    mockSpaceUsers.SpaceUsers.get.mockReturnValue([])
     await subject().requestReview({
       codeReview: mockModel,
       context: mockModel,
@@ -66,6 +69,7 @@ describe('Pull Request Quick Actions', () => {
         context: mockModel,
         placeholder: 'Select a user',
         title: 'Add reviewer to pull request',
+        spaceUsers: [],
       })
     )
     expect(mockPresence.Presence.set).toBeCalled()
@@ -84,6 +88,7 @@ const subject = () => {
   jest.mock('../utils/pullRequestsState', () => mockPullRequestState)
   jest.mock('../views/quickpicks/spaceUserPicker', () => mockSpaceUserPicker)
   jest.mock('../views/quickpicks/timePicker', () => mockTimerPicker)
+  jest.mock('../models/spaceUsers', () => mockSpaceUsers)
   return require('./pullRequestQuickActions').PullRequestQuickActions
 }
 
@@ -107,6 +112,11 @@ const mockPullRequestState = {
   PullRequestState: {
     update: jest.fn(),
     updateWithDelay: jest.fn(),
+  },
+}
+const mockSpaceUsers = {
+  SpaceUsers: {
+    get: jest.fn(),
   },
 }
 const mockSpaceUserPicker = {

--- a/src/pullRequestQuickActions/pullRequestQuickActions.ts
+++ b/src/pullRequestQuickActions/pullRequestQuickActions.ts
@@ -7,6 +7,7 @@ import { Presence } from '../models/presence'
 import { TimeSelectionItem, timePicker } from '../views/quickpicks/timePicker'
 import moment = require('moment')
 import { PullRequestState } from '../utils/pullRequestsState'
+import { SpaceUsers } from '../models/spaceUsers'
 
 export const PullRequestQuickActions = {
   applyLabel: async ({
@@ -118,10 +119,19 @@ export const PullRequestQuickActions = {
     context: ExtensionContext
     statusBar: StatusBarItem
   }) => {
+    const spaceUsers = await SpaceUsers.get({
+      context,
+      codeReviewId: codeReview.id,
+    })
+    if (!spaceUsers) {
+      return false
+    }
+
     spaceUserPicker({
       context,
       placeholder: 'Select a user',
       title: 'Add assignee to pull request',
+      spaceUsers,
       onDidChangeSelection: async (item) => {
         if (!item[0].description) return false
 
@@ -156,6 +166,7 @@ export const PullRequestQuickActions = {
       context,
       statusBar,
     })
+    return true
   },
 
   requestReview: async ({
@@ -167,10 +178,19 @@ export const PullRequestQuickActions = {
     context: ExtensionContext
     statusBar: StatusBarItem
   }) => {
+    const spaceUsers = await SpaceUsers.get({
+      context,
+      codeReviewId: codeReview.id,
+    })
+    if (!spaceUsers) {
+      return false
+    }
+
     spaceUserPicker({
       context,
       placeholder: 'Select a user',
       title: 'Add reviewer to pull request',
+      spaceUsers,
       onDidChangeSelection: async (item) => {
         if (!item[0].description) return false
 
@@ -209,6 +229,7 @@ export const PullRequestQuickActions = {
       context,
       statusBar,
     })
+    return true
   },
 
   refresh: async ({

--- a/src/utils/initialize.ts
+++ b/src/utils/initialize.ts
@@ -2,7 +2,6 @@ import {
   ExtensionContext,
   StatusBarItem,
   WindowState,
-  commands,
   window,
   workspace,
 } from 'vscode'
@@ -11,9 +10,7 @@ import { log } from './logger'
 import { StatusBar } from '../views/statusBar/statusBar'
 import { Authorization } from './authorization'
 import { StatusBarState } from './types'
-import { SpaceUsersApi } from '../api/spaceUsersApi'
 import { PullRequestState } from './pullRequestsState'
-import { Command } from './commands'
 import { trackUserPresence } from '../userPresence/trackUserPresence'
 
 const POLLING_TIME = 60000 // in ms
@@ -103,21 +100,8 @@ const setSpaceUsers = async ({
     return
   }
 
-  const spaceUsers = await SpaceUsersApi.get({
-    authToken: session?.accessToken ?? '',
-    context,
-  })
-  if (spaceUsers.error || spaceUsers.message) {
-    window.showInformationMessage(
-      `Error in fetching space users ${spaceUsers.error || spaceUsers.message}`
-    )
-    commands.executeCommand(Command.signOut)
-    return
-  }
-
   await Store.set(context, {
     isFocused: window.state.focused,
-    spaceUsers: spaceUsers.spaceUsers,
   })
 }
 

--- a/src/views/quickpicks/spaceUserPicker.ts
+++ b/src/views/quickpicks/spaceUserPicker.ts
@@ -1,5 +1,4 @@
-import { ExtensionContext, window } from 'vscode'
-import { Store } from '../../utils/store'
+import { ExtensionContext } from 'vscode'
 import { SpaceUser, SpaceUserSelectionItem } from '../../utils'
 import { QuickPick } from './quickPick'
 
@@ -8,6 +7,7 @@ export const spaceUserPicker = ({
   placeholder,
   title,
   onDidChangeSelection,
+  spaceUsers,
 }: {
   context: ExtensionContext
   placeholder: string
@@ -15,12 +15,8 @@ export const spaceUserPicker = ({
   onDidChangeSelection: (
     item: readonly SpaceUserSelectionItem[]
   ) => Promise<boolean>
+  spaceUsers: SpaceUser[]
 }) => {
-  const spaceUsers = Store.get(context)?.spaceUsers
-  if (!spaceUsers) {
-    window.showInformationMessage(`Failed to find space users`)
-    return
-  }
   const spaceUsersItems = spaceUsers.map((user: SpaceUser) => {
     return {
       label: user.name,


### PR DESCRIPTION
### Summary
SpaceUsersForVSCode in Pullflow 2.0 requires codeReviewId to identify the specific space for the user: codeReview > codeRepo > codeSpace > Space.
This PR changes the Extension to call the API only once the user has selected a code review. 

Dependent on [this PR](https://github.com/pullflow/pullflow/pull/2662).